### PR TITLE
Fix listing users to account for Discord message limit

### DIFF
--- a/discord/interpreter.js
+++ b/discord/interpreter.js
@@ -80,7 +80,13 @@ module.exports.handleCom = (message, client) => {
                 return;
             }
             Winston.log("info", "displaying all users in registeredUsers collection");
-            message.channel.sendMessage(JSON.stringify(auth.getUsers(), null, 4));
+            var output = JSON.stringify(auth.getUsers(), null, 4);
+            var DISCORD_TEXT_LIMIT = 2000;
+            while (output.length > DISCORD_TEXT_LIMIT) {
+              message.channel.sendMessage(output.substring(0, DISCORD_TEXT_LIMIT-1));
+              output = output.substring(DISCORD_TEXT_LIMIT);
+            }
+            message.channel.sendMessage(output);
             break;
         case "!delete_user":
             var nick = command.join(' ');


### PR DESCRIPTION
Discord has a character limit of 2000. If the JSON string has too many
characters then list_users command will not work and an error will be
thrown. This can be solved by splitting the text into 2000 characters
chunks.